### PR TITLE
add support #colorLiteral()

### DIFF
--- a/ColorListGenerator/CodeGenerator.swift
+++ b/ColorListGenerator/CodeGenerator.swift
@@ -19,11 +19,9 @@ enum Code: String {
             func classFunc(_ color: Color) -> String {
                 let methodName = color.name.camelCase().sanitizeAsMethodName()
                 let code =
-                    "    /// \(color.name.camelCase().sanitizeAsMethodName()) color (\(color.hexStringRepresentation()))\n" +
-                    "    /// - returns: \(color.hexStringRepresentation())\n" +
-                    "    class var \(methodName): UIColor {\n" +
-                    "        return UIColor(red: \(Double(color.color!.redComponent)), green: \(Double(color.color!.greenComponent)), blue: \(Double(color.color!.blueComponent)), alpha: \(Double(color.color!.alphaComponent)))\n" +
-                    "    }\n\n"
+                    "    /// \(color.name.camelCase().sanitizeAsMethodName()) color (\(color.hexStringRepresentation(colorSpace: .argb)))\n" +
+                    "    /// - returns: \(color.hexStringRepresentation(colorSpace: .argb))\n" +
+                    "    static let \(methodName): UIColor = #colorLiteral(red: \(Double(color.color!.redComponent)), green: \(Double(color.color!.greenComponent)), blue: \(Double(color.color!.blueComponent)), alpha: \(Double(color.color!.alphaComponent)))\n\n"
                 return code
             }
 

--- a/ColorListGenerator/Color.swift
+++ b/ColorListGenerator/Color.swift
@@ -9,6 +9,11 @@
 import Foundation
 import Cocoa
 
+enum ColorSpace {
+    case rgb
+    case argb
+}
+
 class Color {
 
     var name: String!
@@ -97,16 +102,30 @@ class Color {
         return nil
     }
 
-    func hexStringRepresentation(_ needsHashMark: Bool = true) -> String {
+    func hexStringRepresentation(_ needsHashMark: Bool = true, colorSpace: ColorSpace = .rgb) -> String {
         let x = self.color!
         func toInt(_ component: CGFloat) -> Int {
             return Int(component * 255.0)
         }
 
-        let hex = toInt(x.redComponent) * 0x10000
-            + toInt(x.greenComponent) * 0x100
-            + toInt(x.blueComponent)
-        let hexString = String(format: "%06x", hex).uppercased()
+        let alpha = toInt(color.alphaComponent)
+        
+        let hexString: String
+        switch (colorSpace, alpha) {
+        case (.rgb, _), (.argb, 255):
+            let hex = toInt(x.redComponent) * 0x10000
+                + toInt(x.greenComponent) * 0x100
+                + toInt(x.blueComponent)
+            hexString = String(format: "%06x", hex).uppercased()
+            break
+        case (.argb, _):
+            let hex = toInt(x.alphaComponent) * 0x1000000
+                + toInt(x.redComponent) * 0x10000
+                + toInt(x.greenComponent) * 0x100
+                + toInt(x.blueComponent)
+            hexString = String(format: "%08x", hex).uppercased()
+            break
+        }
         if needsHashMark {
             return "#" + hexString
 


### PR DESCRIPTION
#13 の `#colorLiteral()`に対応しました。

class varからstatic letに変更しています。lazyとして扱われる(初回利用時にキャッシュされてそのまま保持される)ため、気にするほどではありませんが効率的になっています。