### PR TITLE
Add —type option instead —code option.

### DIFF
--- a/Sources/clg/Command/Subcommands/CodeCommand.swift
+++ b/Sources/clg/Command/Subcommands/CodeCommand.swift
@@ -18,14 +18,36 @@ struct CodeCommand: ParsableCommand {
         abstract: "generates Swift code, Objective-C code, Color Set, colors.xml from input"
     )
 
-    @Option(name: [.customLong("code"), .customShort("c")], help: ArgumentHelp("Generate specific type of code file", valueName: Code.allCasesDescription))
-    var codeType: Code
+    @Option(name: [.customLong("code"), .customShort("c")], help: ArgumentHelp("Generate specific type of code file", discussion: "<Deprecated> Use `--type` option instead.", valueName: Code.allCasesDescription, shouldDisplay: false))
+    var _deprecatedCodeType: Code?
+
+    @Option(name: [.customLong("type"), .customShort("t")], help: ArgumentHelp("Generate specific type of code file", valueName: Code.allCasesDescription))
+    var _codeType: Code?
+
+    var codeType: Code {
+        if let d = _deprecatedCodeType {
+            return d
+        }
+
+        return _codeType!
+    }
 
     @Option(name: [.customLong("output"), .customShort("o")], default: Path.cwd/".", help: ArgumentHelp("Output directory that generated file will be saved. (default: current directory)", valueName: "directory"))
     var outputPath: Path
 
     @Argument(help: ArgumentHelp("Supported file types are \(FileType.allCasesDescription)", valueName: "input file"))
     var inputFilePath: Path
+
+    func validate() throws {
+        if _deprecatedCodeType != nil {
+            var stderr = FileHandle.standardError
+            print("<Deprecated> `--code` is deprecated. Use `--type` option instead.", to: &stderr)
+        }
+
+        guard _deprecatedCodeType != nil || _codeType != nil else {
+            throw ValidationError("Missing expected argument '--type <swift, objc, colorset, android>'")
+        }
+    }
 
     func run() throws {
         let fileType = try FileType(from: inputFilePath.url)


### PR DESCRIPTION
`--code` option for `code` subcommand is redundant.  I change `--type` option instead. `--code` option still exists for backward compatibility, but it already disappear on help message.

If the user is still using `--code`, a deprecated message is displayed. We will remove the `--code` option in the future.